### PR TITLE
fix(counter): exluding stopwords and occurences <= 3

### DIFF
--- a/src/lib/counter.ts
+++ b/src/lib/counter.ts
@@ -75,6 +75,8 @@ function paragraphsCounter(string: string): number {
 function commonWords(string: string): CommonWordsObject {
   const wordRegex = /[ \n]/
   const words = string.split(wordRegex)
+  const excludedWords = ['the', 'and', 'to', 'of', 'a', 'in', 'that', 'is', 'was', 'he']
+  
   const normalizedWords = words
     .map((word) =>
       word
@@ -82,6 +84,7 @@ function commonWords(string: string): CommonWordsObject {
         .replace(/[.,!?;:]\s*$/, '')
         .toLowerCase(),
     )
+    .filter(word => !excludedWords.includes(word))
     .sort()
     .filter(hasNoSpace)
 
@@ -93,7 +96,11 @@ function commonWords(string: string): CommonWordsObject {
     {},
   )
 
-  return Object.entries(wordCount)
+  const filteredWordCount = Object.entries(wordCount).filter(
+    ([, count]: [string, number]) => count > 3,
+  )
+
+  return filteredWordCount
     .sort(([, a]: any, [, b]: any) => b - a)
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
 }

--- a/src/lib/counter.ts
+++ b/src/lib/counter.ts
@@ -75,8 +75,19 @@ function paragraphsCounter(string: string): number {
 function commonWords(string: string): CommonWordsObject {
   const wordRegex = /[ \n]/
   const words = string.split(wordRegex)
-  const excludedWords = ['the', 'and', 'to', 'of', 'a', 'in', 'that', 'is', 'was', 'he']
-  
+  const excludedWords = [
+    'the',
+    'and',
+    'to',
+    'of',
+    'a',
+    'in',
+    'that',
+    'is',
+    'was',
+    'he',
+  ]
+
   const normalizedWords = words
     .map((word) =>
       word
@@ -84,7 +95,7 @@ function commonWords(string: string): CommonWordsObject {
         .replace(/[.,!?;:]\s*$/, '')
         .toLowerCase(),
     )
-    .filter(word => !excludedWords.includes(word))
+    .filter((word) => !excludedWords.includes(word))
     .sort()
     .filter(hasNoSpace)
 


### PR DESCRIPTION
### Summary

This pull request optimizes the `commonWords` function by introducing filtering for common stop words and adjusting the word counting mechanism to reduce noise. The key changes include:

1. **Stop Words Filtering**: Excludes common stop words such as "the," "and," "to," etc., to focus on more meaningful words.
2. **Count Filtering**: Only includes words that appear more than 3 times to further reduce noise and highlight significant words.

### Detailed Changes

- **Stop Words Exclusion**:
  - Added an array `excludedWords` containing the most common English stop words.
  - Modified the `normalizedWords` map function to filter out words present in `excludedWords`.
  
- **Count Threshold**:
  - Introduced a filter step to only include words with a count greater than 3 in the final output.

### Benefits

- **Improved Relevance**: By excluding common stop words, the function now highlights more relevant and meaningful words in the text.
- **Noise Reduction**: The additional filter for word count ensures that only frequently occurring words are included, reducing the noise from less significant words.
- **Enhanced Readability**: The output is more focused and easier to interpret, providing better insights from the text analysis.
